### PR TITLE
Add OSGi Headers to the final artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,9 +204,29 @@
             <exclude>**/.gitignore</exclude>
             <exclude>**/log4j2.xml</exclude>
           </excludes>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
         </configuration>
       </plugin>
-
+      <plugin>
+		    <groupId>biz.aQute.bnd</groupId>
+		    <artifactId>bnd-maven-plugin</artifactId>
+		    <version>6.4.0</version>
+		    <executions>
+		        <execution>
+		            <id>bnd-process</id>
+		            <goals>
+		                <goal>bnd-process</goal>
+		            </goals>
+		             <configuration>
+				        <bnd><![CDATA[
+				            Export-Package= nz.ac.waikato.*;-noimport:=true
+				        ]]></bnd>
+				    </configuration>
+		        </execution>
+		    </executions>
+		</plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
[OSGi](https://www.osgi.org/) allows to build modular applications, for this to work it reads some extra headers from the `MAINFEST.MF` file of a jar file.

This PR adds the [bnd-maven-plugin](https://github.com/bndtools/bnd/blob/master/maven-plugins/bnd-maven-plugin/README.md) to generate these headers automatically.